### PR TITLE
Improve treatment of package source

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,11 +7,18 @@
 ##   String giving email address to receive alerts; or an array of strings.
 ## @param pkgurl
 ##   String specifying URL to fetch sources from
+## @param pkgurl_user
+##   String specifying username for pkgurl
+## @param pkgurl_pass
+##   String specifying password for pkgurl
+
 
 class ccs_monit (
   String $mailhost = 'localhost',
   Variant[String,Array[String]] $alert = 'root@localhost',
   String $pkgurl = 'https://example.org',
+  String $pkgurl_user = 'someuser',
+  String $pkgurl_pass = 'somepass',
 ) {
 
   ensure_packages(['monit', 'freeipmi'])
@@ -212,8 +219,10 @@ class ccs_monit (
     $perc = 'perccli64'
     $percfile = "/var/tmp/${perc}"
     archive { $percfile:
-      ensure => present,
-      source => "${pkgurl}/${perc}",
+      ensure   => present,
+      source   => "${pkgurl}/${perc}",
+      username => $pkgurl_user,
+      password => $pkgurl_pass,
     }
     file { "/usr/local/bin/${perc}":
       ensure => present,
@@ -245,8 +254,10 @@ class ccs_monit (
   $exefile = "/var/tmp/${exe}"
 
   archive { $exefile:
-    ensure => present,
-    source => "${pkgurl}/${exe}",
+    ensure   => present,
+    source   => "${pkgurl}/${exe}",
+    username => $pkgurl_user,
+    password => $pkgurl_pass,
   }
 
   ## archive does not support mode.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,10 +5,13 @@
 ##   String specifying smtp server
 ## @param alert
 ##   String giving email address to receive alerts; or an array of strings.
+## @param pkgurl
+##   String specifying URL to fetch sources from
 
 class ccs_monit (
   String $mailhost = 'localhost',
   Variant[String,Array[String]] $alert = 'root@localhost',
+  String $pkgurl = 'https://example.org',
 ) {
 
   ensure_packages(['monit', 'freeipmi'])
@@ -195,7 +198,6 @@ class ccs_monit (
   }
 
 
-  $ccs_pkgarchive = lookup('ccs_pkgarchive', String)
   $hwraid = lookup('ccs_monit::hwraid', Boolean, undef, $notvirt)
 
   if $hwraid {
@@ -211,7 +213,7 @@ class ccs_monit (
     $percfile = "/var/tmp/${perc}"
     archive { $percfile:
       ensure => present,
-      source => "${ccs_pkgarchive}/${perc}",
+      source => "${pkgurl}/${perc}",
     }
     file { "/usr/local/bin/${perc}":
       ensure => present,
@@ -244,7 +246,7 @@ class ccs_monit (
 
   archive { $exefile:
     ensure => present,
-    source => "${ccs_pkgarchive}/${exe}",
+    source => "${pkgurl}/${exe}",
   }
 
   ## archive does not support mode.


### PR DESCRIPTION
Package source is now a class parameter, rather than an explicit lookup.
Add username and password for fetching sources (needed for nexus).