### PR TITLE
modulesync 5.3.0 + general cleanup + EL7/EL8/EL9 acceptance testing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# editorconfig.org
+
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+tab_width = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,4 @@
+---
+fixtures:
+  forge_modules:
+    stdlib: "puppetlabs/stdlib"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+---
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+name: CI
+
+on: pull_request
+
+concurrency:
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  puppet:
+    name: Puppet
+    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v1
+    with:
+      pidfile_workaround: 'false'

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -1,0 +1,17 @@
+---
+# yamllint disable rule:quoted-strings
+name: markdownlint
+
+"on":
+  - push
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run mdl
+        uses: actionshub/markdownlint@main
+        with:
+          filesToIgnoreRegex: "REFERENCE.md"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+---
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    name: Release
+    uses: voxpupuli/gha-puppet/.github/workflows/release.yml@v1
+    with:
+      allowed_owner: 'lsst-it'
+    secrets:
+      # Configure secrets here:
+      #  https://docs.github.com/en/actions/security-guides/encrypted-secrets
+      username: ${{ secrets.PUPPET_FORGE_USERNAME }}
+      api_key: ${{ secrets.PUPPET_FORGE_API_KEY }}

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,0 +1,15 @@
+---
+# yamllint disable rule:quoted-strings
+name: shellcheck
+
+"on":
+  - push
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -1,0 +1,15 @@
+---
+# yamllint disable rule:quoted-strings
+name: yamllint
+
+"on":
+  - push
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run yamllint
+        uses: bewuethr/yamllint-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+pkg/
+Gemfile.lock
+Gemfile.local
+vendor/
+.vendor/
+spec/fixtures/manifests/
+spec/fixtures/modules/
+.vagrant/
+.bundle/
+.ruby-version
+coverage/
+log/
+.idea/
+.dependencies/
+.librarian/
+Puppetfile.lock
+*.iml
+.*.sw?
+.yardoc/
+Guardfile

--- a/.msync.yml
+++ b/.msync.yml
@@ -1,0 +1,5 @@
+---
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+modulesync_config_version: '5.3.0'

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,65 @@
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+#
+# Hooks are only enabled if you take action.
+#
+# To enable the hooks run:
+#
+# ```
+# bundle exec overcommit --install
+# # ensure .overcommit.yml does not harm to you and then
+# bundle exec overcommit --sign
+# ```
+#
+# (it will manage the .git/hooks directory):
+#
+# Examples howto skip a test for a commit or push:
+#
+# ```
+# SKIP=RuboCop git commit
+# SKIP=PuppetLint git commit
+# SKIP=RakeTask git push
+# ```
+#
+# Don't invoke overcommit at all:
+#
+# ```
+# OVERCOMMIT_DISABLE=1 git commit
+# ```
+#
+# Read more about overcommit: https://github.com/brigade/overcommit
+#
+# To manage this config yourself in your module add
+#
+# ```
+# .overcommit.yml:
+#   unmanaged: true
+# ```
+#
+# to your modules .sync.yml config
+---
+PreCommit:
+  RuboCop:
+    enabled: true
+    description: 'Runs rubocop on modified files only'
+    command: ['bundle', 'exec', 'rubocop']
+  PuppetLint:
+    enabled: true
+    description: 'Runs puppet-lint on modified files only'
+    command: ['bundle', 'exec', 'puppet-lint']
+  YamlSyntax:
+    enabled: true
+  JsonSyntax:
+    enabled: true
+  TrailingWhitespace:
+    enabled: true
+
+PrePush:
+  RakeTarget:
+    enabled: true
+    description: 'Run rake targets'
+    targets:
+      - 'validate'
+      - 'test'
+      - 'rubocop'
+    command: ['bundle', 'exec', 'rake']

--- a/.pmtignore
+++ b/.pmtignore
@@ -1,0 +1,37 @@
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+docs/
+pkg/
+Gemfile
+Gemfile.lock
+Gemfile.local
+vendor/
+.vendor/
+spec/
+Rakefile
+.vagrant/
+.bundle/
+.ruby-version
+coverage/
+log/
+.idea/
+.dependencies/
+.github/
+.librarian/
+Puppetfile.lock
+*.iml
+.editorconfig
+.fixtures.yml
+.gitignore
+.msync.yml
+.overcommit.yml
+.pmtignore
+.rspec
+.rspec_parallel
+.rubocop.yml
+.sync.yml
+.*.sw?
+.yardoc/
+.yardopts
+Dockerfile

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,1 @@
+--fail-on-warnings

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,5 @@
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+--format documentation
+--color

--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,4 @@
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+--format progress

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,6 @@
+---
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+inherit_gem:
+  voxpupuli-test: rubocop.yml

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,0 +1,31 @@
+---
+.puppet-lint.rc:
+  enabled_lint_checks:
+    - parameter_documentation
+    - parameter_types
+
+spec/spec_helper_acceptance.rb:
+  unmanaged: false
+
+.github/CONTRIBUTING.md:
+  delete: true
+.github/ISSUE_TEMPLATE.md:
+  delete: true
+.github/PULL_REQUEST_TEMPLATE.md:
+  delete: true
+.github/SECURITY.md:
+  delete: true
+
+Gemfile:
+  optional:
+    ':test':
+      - gem: puppet-lint-legacy_facts-check
+      - gem: puppet-lint-no_erb_template-check
+      - gem: puppet-lint-package_ensure-check
+      - gem: puppet-lint-resource_reference_syntax
+      - gem: puppet-lint-strict_indent-check
+      - gem: puppet-lint-template_file_extension-check
+      - gem: puppet-lint-top_scope_facts-check
+      - gem: puppet-lint-trailing_newline-check
+      - gem: puppet-lint-unquoted_string-check
+      - gem: puppet-lint-variable_contains_upcase

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# MANAGED BY MODULESYNC
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+FROM ruby:2.7
+
+WORKDIR /opt/puppet
+
+# https://github.com/puppetlabs/puppet/blob/06ad255754a38f22fb3a22c7c4f1e2ce453d01cb/lib/puppet/provider/service/runit.rb#L39
+RUN mkdir -p /etc/sv
+
+ARG PUPPET_GEM_VERSION="~> 6.0"
+ARG PARALLEL_TEST_PROCESSORS=4
+
+# Cache gems
+COPY Gemfile .
+RUN bundle install --without system_tests development release --path=${BUNDLE_PATH:-vendor/bundle}
+
+COPY . .
+
+RUN bundle install
+RUN bundle exec rake release_checks
+
+# Container should not saved
+RUN exit 1

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,44 @@
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+
+group :test do
+  gem 'voxpupuli-test', '~> 5.4',                   :require => false
+  gem 'coveralls',                                  :require => false
+  gem 'simplecov-console',                          :require => false
+  gem 'puppet_metadata', '~> 1.0',                  :require => false
+  gem 'puppet-lint-legacy_facts-check',             :require => false
+  gem 'puppet-lint-no_erb_template-check',          :require => false
+  gem 'puppet-lint-package_ensure-check',           :require => false
+  gem 'puppet-lint-resource_reference_syntax',      :require => false
+  gem 'puppet-lint-strict_indent-check',            :require => false
+  gem 'puppet-lint-template_file_extension-check',  :require => false
+  gem 'puppet-lint-top_scope_facts-check',          :require => false
+  gem 'puppet-lint-trailing_newline-check',         :require => false
+  gem 'puppet-lint-unquoted_string-check',          :require => false
+  gem 'puppet-lint-variable_contains_upcase',       :require => false
+end
+
+group :development do
+  gem 'guard-rake',               :require => false
+  gem 'overcommit', '>= 0.39.1',  :require => false
+end
+
+group :system_tests do
+  gem 'voxpupuli-acceptance', '~> 1.0',  :require => false
+end
+
+group :release do
+  gem 'github_changelog_generator', '>= 1.16.1',  :require => false if RUBY_VERSION >= '2.5'
+  gem 'voxpupuli-release', '>= 1.2.0',            :require => false
+  gem 'puppet-strings', '>= 2.2',                 :require => false
+end
+
+gem 'rake', :require => false
+gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
+
+puppetversion = ENV['PUPPET_GEM_VERSION'] || '>= 6.0'
+gem 'puppet', puppetversion, :require => false, :groups => [:test]
+
+# vim: syntax=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,72 @@
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+# Attempt to load voxpupuli-test (which pulls in puppetlabs_spec_helper),
+# otherwise attempt to load it directly.
+begin
+  require 'voxpupuli/test/rake'
+rescue LoadError
+  begin
+    require 'puppetlabs_spec_helper/rake_tasks'
+  rescue LoadError
+  end
+end
+
+# load optional tasks for acceptance
+# only available if gem group releases is installed
+begin
+  require 'voxpupuli/acceptance/rake'
+rescue LoadError
+end
+
+# load optional tasks for releases
+# only available if gem group releases is installed
+begin
+  require 'voxpupuli/release/rake_tasks'
+rescue LoadError
+end
+
+desc "Run main 'test' task and report merged results to coveralls"
+task test_with_coveralls: [:test] do
+  if Dir.exist?(File.expand_path('../lib', __FILE__))
+    require 'coveralls/rake/task'
+    Coveralls::RakeTask.new
+    Rake::Task['coveralls:push'].invoke
+  else
+    puts 'Skipping reporting to coveralls.  Module has no lib dir'
+  end
+end
+
+desc 'Generate REFERENCE.md'
+task :reference, [:debug, :backtrace] do |t, args|
+  patterns = ''
+  Rake::Task['strings:generate:reference'].invoke(patterns, args[:debug], args[:backtrace])
+end
+
+begin
+  require 'github_changelog_generator/task'
+  require 'puppet_blacksmith'
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    metadata = Blacksmith::Modulefile.new
+    config.future_release = "v#{metadata.version}" if metadata.version =~ /^\d+\.\d+.\d+$/
+    config.header = "# Changelog\n\nAll notable changes to this project will be documented in this file.\nEach new release typically also includes the latest modulesync defaults.\nThese should not affect the functionality of the module."
+    config.exclude_labels = %w{duplicate question invalid wontfix wont-fix modulesync skip-changelog}
+    config.user = 'voxpupuli'
+    config.project = metadata.metadata['name']
+  end
+
+  # Workaround for https://github.com/github-changelog-generator/github-changelog-generator/issues/715
+  require 'rbconfig'
+  if RbConfig::CONFIG['host_os'] =~ /linux/
+    task :changelog do
+      puts 'Fixing line endings...'
+      changelog_file = File.join(__dir__, 'CHANGELOG.md')
+      changelog_txt = File.read(changelog_file)
+      new_contents = changelog_txt.gsub(%r{\r\n}, "\n")
+      File.open(changelog_file, "w") {|file| file.puts new_contents }
+    end
+  end
+
+rescue LoadError
+end
+# vim: syntax=ruby

--- a/examples/basic.pp
+++ b/examples/basic.pp
@@ -1,0 +1,3 @@
+ensure_packages(['epel-release'])
+Package['epel-release'] -> Class['ccs_monit']
+include ccs_monit

--- a/files/monit_hwraid
+++ b/files/monit_hwraid
@@ -21,6 +21,7 @@ type -ap $raid >& /dev/null || {
     exit 1
 }
 
+# shellcheck disable=SC2086
 stat=$($raid $args 2> /dev/null | grep $patt)
 
 [ "$1" = "-p" ] && echo "$stat"

--- a/files/monit_hwraid
+++ b/files/monit_hwraid
@@ -4,7 +4,7 @@
 ## Check the status of hardware raid.
 ## Assumes the relevant hwraid utility is installed.
 
-PATH=$PATH:/usr/local/bin
+PATH=$PATH:/usr/local/bin:/opt/MegaRAID/perccli
 
 raid=perccli64
 args="/c0/vall show"

--- a/files/monit_inlet_temp
+++ b/files/monit_inlet_temp
@@ -25,9 +25,9 @@ printf "%s\n" "$*" >&2;
 # called on trap triggered exit
 function cleanexit {
 set +u
-rm -f $LOCKFILE
+rm -f "$LOCKFILE"
 echoerr -n "cleanexit(): "
-echoerr $(date --utc '+%Y%m%d%H%M%S')
+echoerr "$(date --utc '+%Y%m%d%H%M%S')"
 exit $?
 }
 
@@ -40,7 +40,6 @@ exit $?
 #fi
 
 LOCKDIR=/tmp
-PROGPATH=$0
 PROG=${0##*/}
 PID=$$
 dir0=$PWD
@@ -56,7 +55,7 @@ then
     trap cleanexit INT TERM EXIT
 else
     echoerr "Failed to acquire lockfile: $LOCKFILE."
-    echoerr "Held by PID $(< $LOCKFILE)"
+    echoerr "Held by PID $(< "$LOCKFILE")"
     echoerr "exiting"
     exit 1
 fi
@@ -65,19 +64,18 @@ fi
 thresh=25
 temp=$(ipmi-sensors -t temperature --no-header-output --comma |\
    gawk -F, '/Inlet/ {printf("%d\n",$4);}')
-if [ $temp -lt $thresh ] ; then
-   echoerr Inlet temp=$temp \< threshold=$thresh
+if [ "$temp" -lt "$thresh" ] ; then
+   echoerr Inlet temp="$temp" \< threshold=$thresh
    retval=0
 else
-   echoerr Inlet air temp=$temp \> threshold=$thresh
+   echoerr Inlet air temp="$temp" \> threshold=$thresh
    retval=$temp
 fi
 #---------------------------------------------------------------------------
 #- end of script, remove trap
 #---------------------------------------------------------------------------
 trap - INT TERM EXIT
-rm -f $LOCKFILE
-cd $dir0
-echoerr exit at: $(date --utc '+%Y%m%d%H%M%S')
-exit $retval
-
+rm -f "$LOCKFILE"
+cd "$dir0" || exit "$retval"
+echoerr exit at: "$(date --utc '+%Y%m%d%H%M%S')"
+exit "$retval"

--- a/files/monit_netspeed
+++ b/files/monit_netspeed
@@ -11,9 +11,10 @@ eth0=$(nmcli -g ip4.address,general.device dev show 2> /dev/null | \
   gawk '/^(134|140|139)/ {getline; print $0; exit}')
 
 [ "$eth0" ] || {
-    read uptime idle < /proc/uptime
+    # shellcheck disable=SC2034
+    read -r uptime idle < /proc/uptime
     ## Avoid bogus warnings right after reboot.
-    [ ${uptime%%.*} -lt 180 ] && exit 0
+    [ "${uptime%%.*}" -lt 180 ] && exit 0
     echo "$HOSTNAME: Unable to determine primary network interface"
     exit 1
 }
@@ -21,9 +22,9 @@ eth0=$(nmcli -g ip4.address,general.device dev show 2> /dev/null | \
 ## If a bridge, find the real interface.
 ## Eg lsst-vs01 shows "p5p1" and "vnet0".
 ip -br link show type bridge | grep -q "^$eth0 " && \
-    eth0=$(ip -c -br link show master $eth0 | grep -v ^v | cut -f1 -d' ')
+    eth0=$(ip -c -br link show master "$eth0" | grep -v ^v | cut -f1 -d' ')
 
-speed=$(ethtool $eth0 2> /dev/null | sed -n 's/.*Speed: *\([0-9]*\).*/\1/p')
+speed=$(ethtool "$eth0" 2> /dev/null | sed -n 's/.*Speed: *\([0-9]*\).*/\1/p')
 
 case $speed in
     ""|*[^0-9]*) echo "Non-integer speed: $speed" ; exit 1 ;;
@@ -38,7 +39,7 @@ esac
 [ "$1" = "-p" ] && \
     echo "Interface = $eth0, speed = $speed, expected = $expected"
 
-[ $speed -ge $expected ] && exit 0
+[ "$speed" -ge "$expected" ] && exit 0
 
 echo "Speed is low: $speed < $expected"
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -191,9 +191,7 @@ class ccs_monit (
     mode   => '0755',
   }
 
-  $hwraid = lookup('ccs_monit::hwraid', Boolean, undef, $notvirt)
-
-  if $hwraid {
+  if fact('has_dellperc') {
     $hwraidf = 'hwraid'
     file { "${monitd}/${hwraidf}":
       ensure => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -199,20 +199,6 @@ class ccs_monit (
       notify => Service['monit'],
     }
 
-    $perc = 'perccli64'
-    $percfile = "/var/tmp/${perc}"
-    archive { $percfile:
-      ensure   => present,
-      source   => "${pkgurl}/${perc}",
-      username => $pkgurl_user,
-      password => $pkgurl_pass,
-    }
-    file { "/usr/local/bin/${perc}":
-      ensure => file,
-      source => $percfile,
-      mode   => '0755',
-    }
-
     ## Needs the raid utility (eg perccli64) to be installed.
     $hexe = 'monit_hwraid'
     file { "/usr/local/bin/${hexe}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,17 +1,17 @@
-## @summary
-##   Install and configure monit.
-##
-## @param mailhost
-##   String specifying smtp server
-## @param alert
-##   String giving email address to receive alerts; or an array of strings.
-## @param pkgurl
-##   String specifying URL to fetch sources from
-## @param pkgurl_user
-##   String specifying username for pkgurl
-## @param pkgurl_pass
-##   String specifying password for pkgurl
-
+# @summary
+#   Install and configure monit.
+#
+# @param mailhost
+#   String specifying smtp server
+# @param alert
+#   String giving email address to receive alerts; or an array of strings.
+# @param pkgurl
+#   String specifying URL to fetch sources from
+# @param pkgurl_user
+#   String specifying username for pkgurl
+# @param pkgurl_pass
+#   String specifying password for pkgurl
+#
 class ccs_monit (
   String $mailhost = 'localhost',
   Variant[String,Array[String]] $alert = 'root@localhost',
@@ -253,4 +253,5 @@ class ccs_monit (
   service { 'monit':
     ensure => running,
     enable => true,
-} }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -207,32 +207,6 @@ class ccs_monit (
     }
   }
 
-  $service = '/etc/systemd/system/monit.service'
-  exec { 'Create monit.service':
-    path    => ['/usr/bin'],
-    command => "sh -c \"sed 's|/usr/bin/monit|/usr/local/bin/monit|g' /usr/lib/systemd/system/monit.service > ${service}\"",
-    creates => $service,
-  }
-
-  ## Note that we configure this monit with --prefix=/usr so that
-  ## it consults /etc/monitrc, and install just the binary by hand.
-  $exe = 'monit'
-  $exefile = "/var/tmp/${exe}"
-
-  archive { $exefile:
-    ensure   => present,
-    source   => "${pkgurl}/${exe}",
-    username => $pkgurl_user,
-    password => $pkgurl_pass,
-  }
-
-  ## archive does not support mode.
-  file { "/usr/local/bin/${exe}":
-    ensure => file,
-    source => $exefile,
-    mode   => '0755',
-  }
-
   service { 'monit':
     ensure => running,
     enable => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -172,7 +172,7 @@ class ccs_monit (
   $network = lookup('ccs_monit::network', Boolean, undef, $notvirt)
 
   if $network {
-    $main_interface = $profile::ccs::facts::main_interface
+    $main_interface = fact('networking.primary')
     $nfile = 'network'
     file { "${monitd}/${nfile}":
       ensure  => file,

--- a/metadata.json
+++ b/metadata.json
@@ -11,10 +11,6 @@
       "version_requirement": ">= 4.13.1 < 9.0.0"
     },
     {
-      "name": "puppet/archive",
-      "version_requirement": ">= 4.0.0 < 7.0.0"
-    },
-    {
       "name": "lsst/dellperc",
       "version_requirement": ">= 1.0.0 < 2.0.0"
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,62 @@
+{
+  "name": "lsst-ccs_monit",
+  "version": "0.2.0",
+  "author": "AURA/LSST/SLAC",
+  "summary": "Manage monit.",
+  "license": "Apache-2.0",
+  "source": "https://github.com/lsst-it/puppet-ccs_monit",
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.13.1 < 9.0.0"
+    },
+    {
+      "name": "puppet/archive",
+      "version_requirement": ">= 4.0.0 < 7.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7",
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7",
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 6.0.0 < 8.0.0"
+    }
+  ]
+}

--- a/metadata.json
+++ b/metadata.json
@@ -13,6 +13,10 @@
     {
       "name": "puppet/archive",
       "version_requirement": ">= 4.0.0 < 7.0.0"
+    },
+    {
+      "name": "lsst/dellperc",
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'ccs_monit class' do
+  include_examples 'the example', 'basic.pp'
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'ccs_monit' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      it { is_expected.to compile.with_all_deps }
+    end
+  end
+end

--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -1,0 +1,4 @@
+---
+mountpoints:
+  /:
+    device: '/dev/mapper/root'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+# puppetlabs_spec_helper will set up coverage if the env variable is set.
+# We want to do this if lib exists and it hasn't been explicitly set.
+ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../lib', __dir__))
+
+require 'voxpupuli/test/spec_helper'
+
+if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
+  facts = YAML.safe_load(File.read(File.join(__dir__, 'default_module_facts.yml')))
+  facts&.each do |name, value|
+    add_custom_fact name.to_sym, value
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+require 'voxpupuli/acceptance/spec_helper_acceptance'
+
+configure_beaker
+
+Dir['./spec/support/acceptance/**/*.rb'].sort.each { |f| require f }


### PR DESCRIPTION
* The `lookup()` for the `ccs_monit::hwraid` hiera key has been removed and replaced with the `has_dellperc` fact. 
* All other `lookup()`s have been converted to class parameters.
* The dependency on `$profile::ccs::facts::main_interface` has been removed.