### PR TITLE
(files/monit_hwraid) no error if RAID not configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v2.2.0](https://github.com/lsst-it/puppet-ccs_monit/tree/v2.2.0) (2024-03-26)
+
+[Full Changelog](https://github.com/lsst-it/puppet-ccs_monit/compare/v2.1.0...v2.2.0)
+
+**Implemented enhancements:**
+
+- Allow multiple mailservers, default to localhost [\#20](https://github.com/lsst-it/puppet-ccs_monit/pull/20) ([glennmorris](https://github.com/glennmorris))
+
 ## [v2.1.0](https://github.com/lsst-it/puppet-ccs_monit/tree/v2.1.0) (2023-08-22)
 
 [Full Changelog](https://github.com/lsst-it/puppet-ccs_monit/compare/v2.0.0...v2.1.0)

--- a/files/monit_hwraid
+++ b/files/monit_hwraid
@@ -26,9 +26,13 @@ stat=$($raid $args 2> /dev/null | grep $patt)
 
 [ "$1" = "-p" ] && echo "$stat"
 
+## No RAID configured.
+## We used to return an error here, but several systems have RAID
+## controllers but no configured RAID disks, so now we are just silent.
 [ "$stat" ] || {
-    echo "Unable to get RAID status"
-    exit 1
+    #echo "Unable to get RAID status"
+    #exit 1
+    exit 0
 }
 
 echo "$stat" | grep -qv $ok || exit 0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "lsst-ccs_monit",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "AURA/LSST/SLAC",
   "summary": "Manage monit.",
   "license": "Apache-2.0",


### PR DESCRIPTION
This will suppress some bogus alerts on systems like TTS, which have RAID controllers but are not using RAID disks.